### PR TITLE
Replace shebang for portability sake

### DIFF
--- a/gh-label
+++ b/gh-label
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Based on https://github.com/vilmibm/gh-user-status/blob/533285348c0354064d79053da39aa75f17b5c55f/gh-user-status
 


### PR DESCRIPTION
The used shebang (#!/bin/bash)
has greater chance to fail (as it does on NixOS, for example).

en.wikipedia.org/w/index.php?title=Shebang_(Unix)&oldid=878552871#Portability