### PR TITLE
Downgrade from Go 1.17 to 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ defaults:
     shell: bash
 
 env:
-  GOVERSION: 1.17
+  # TODO: Update once cli/gh-extension-precompile#5 is resolved.
+  GOVERSION: 1.16
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ defaults:
     shell: bash
 
 env:
-  GOVERSION: 1.17
+  # TODO: Update once cli/gh-extension-precompile#5 is resolved.
+  GOVERSION: 1.16
 
 jobs:
   publish:


### PR DESCRIPTION
The cli/gh-extension-precompile action hardcodes 1.16 causing compiler
errors during build. See cli/gh-extension-precompile#5 for details.
